### PR TITLE
added add-apt-repository ppa:mapnik/boost

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,6 +18,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.provision "shell", inline: <<-shell
+    apt-get update
+    apt-get install python-software-properties  -y --force-yes
+    add-apt-repository ppa:mapnik/boost
     wget -O - http://dl.hhvm.com/conf/hhvm.gpg.key | sudo apt-key add -
     echo deb http://dl.hhvm.com/ubuntu precise main | sudo tee /etc/apt/sources.list.d/hhvm.list
     apt-get update


### PR DESCRIPTION
Hi

First at all thanks for this excellent project, i was playing with it and currenlty looks like not works.

I checked the [documentation](https://github.com/facebook/hhvm/wiki/Prebuilt-Packages-on-Ubuntu-12.04) of HHVM and looks like is missing the command `add-apt-repository ppa:mapnik/boost`

With this patch now works perfect!

Regards
