### PR TITLE
Installing Nginx w/ FastCGI.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,9 +21,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     apt-get update
     apt-get install python-software-properties  -y --force-yes
     add-apt-repository ppa:mapnik/boost
+    add-apt-repository ppa:nginx/stable
     wget -O - http://dl.hhvm.com/conf/hhvm.gpg.key | sudo apt-key add -
     echo deb http://dl.hhvm.com/ubuntu precise main | sudo tee /etc/apt/sources.list.d/hhvm.list
     apt-get update
+    apt-get install nginx -y --force-yes
     apt-get install hhvm-nightly -y --force-yes
     apt-get install screen vim -y --force-yes
     debconf-set-selections <<< 'mysql-server-5.5 mysql-server/root_password password pa$$'
@@ -33,6 +35,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     sudo chown vagrant /etc/hhvm
     sudo cp /vagrant/conf/config.hdf /etc/hhvm/my-config.hdf
     sudo cp /vagrant/conf/php.ini /etc/hhvm/my-php.ini
+    sudo rm /etc/nginx/sites-enabled/default
+    sudo cp /vagrant/conf/nginx-fastcgi /etc/nginx/sites-available/nginx-fastcgi
+    sudo ln -s /etc/nginx/sites-available/nginx-fastcgi /etc/nginx/sites-enabled/nginx-fastcgi
+    sudo service nginx restart
 
     hhvm -m daemon -c /etc/hhvm/my-config.hdf
   shell

--- a/conf/config.hdf
+++ b/conf/config.hdf
@@ -1,7 +1,8 @@
 PidFile = /var/hhvm/hhvm.pid
 
 Server {
-  Port = 80
+  Port = 9000
+  Type = fastcgi
   SourceRoot = /vagrant/www
   DefaultDocument = index.php
 }
@@ -47,7 +48,7 @@ Repo {
   }
 }
 
-#include "/usr/share/hhvm/hdf/static.mime-types.hdf"
+# include "/usr/share/hhvm/hdf/static.mime-types.hdf"
 StaticFile {
   FilesMatch {
     * {

--- a/conf/nginx-fastcgi
+++ b/conf/nginx-fastcgi
@@ -1,0 +1,35 @@
+# FastCGI Redirect to HHVM
+# 	Assumes HHVM is on port 9000.
+
+server {
+	listen 80 default_server;
+	listen [::]:80 default_server ipv6only=on;
+
+	root /vagrant/www;
+	index index.html index.htm index.hh index.php;
+
+	# Make site accessible from http://localhost/
+	server_name localhost;
+	
+       location / {
+                index index.php;
+                try_files $uri $uri/ @handler;
+                expires 30d;
+        }
+        location @handler {
+                rewrite / /index.php;
+        }
+        location ~ .(php|hh)$ {
+                fastcgi_keep_conn on;
+                if (!-e $request_filename) { rewrite / /index.php last; }
+                expires        off;
+                fastcgi_pass   127.0.0.1:9000;
+                fastcgi_param PHP_VALUE "error_log=/var/report/PHP.error.log";
+                fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+                include        fastcgi_params;
+        }
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+                expires 1y;
+                log_not_found off;
+        }
+}


### PR DESCRIPTION
I've added Nginx to the provisioning script and configured FastCGI to redirect to HHVM. Chose to go with Nginx rather than Apache on the recommendation of a couple people in the IRC channel, plus it has FastCGI without needing any additional modules. I'm hoping that the simpler installation process will make Nginx the easier of the two options to maintain as HHVM evolves.

Thanks for putting your Vagrant build on GitHub, by the way – I'm just getting started with HHVM and this was quite helpful.

Resolves #3
